### PR TITLE
qualcommax: ipq807x: add Netgear DEVICE_VARS

### DIFF
--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -1,3 +1,5 @@
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+
 define Build/asus-fake-ramdisk
 	rm -rf $(KDIR)/tmp/fakerd
 	dd if=/dev/zero bs=32 count=1 > $(KDIR)/tmp/fakerd


### PR DESCRIPTION
Add NETGEAR_BOARD_ID and NETGEAR_HW_ID to DEVICE_VARS as multiple devices set them in their recipes, so without them being added to DEVICE_VARS then simply the value from last recipe that gets evaluated is used and images are generated with the wrong ID-s.

Link: https://github.com/openwrt/openwrt/pull/17203

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
